### PR TITLE
Set Recipient data value to `null` if `null` is passed to `addData()`

### DIFF
--- a/__tests__/Recipient/addData.test.js
+++ b/__tests__/Recipient/addData.test.js
@@ -15,6 +15,7 @@ test('Should set the right attributes and infer the type correctly on the recipi
     date: new Date(),
     number: 1,
     string: 'string',
+    removeAttribute: null,
   });
 
   expect(typeof r.data.number).toEqual('number');
@@ -28,6 +29,8 @@ test('Should set the right attributes and infer the type correctly on the recipi
 
   expect(typeof r.data.boolean).toEqual('boolean');
   expect(r.data.boolean).toEqual(false);
+
+  expect(r.data.removeAttribute).toEqual(null);
 });
 
 test("Shouldn't overwrite the attributes object when using set after adding data with other methods", () => {
@@ -39,11 +42,13 @@ test("Shouldn't overwrite the attributes object when using set after adding data
     date: new Date(),
     number: 1,
     string: 'string',
+    removeAttribute: null,
   });
 
   expect(r.data.boolean).toEqual(false);
   expect(r.data.date.length).toEqual(24);
   expect(r.data.number).toEqual(1);
   expect(r.data.string).toEqual('string');
+  expect(r.data.removeAttribute).toEqual(null);
   expect(r.data.test).toEqual('123');
 });

--- a/src/Recipient/addData.js
+++ b/src/Recipient/addData.js
@@ -2,6 +2,10 @@ const { argsValidation } = require('../lib/helpers');
 
 module.exports = function addData(obj = {}) {
   Object.entries(obj).forEach(([name, value]) => {
+    if (value === null) {
+      return (this.data[name] = null);
+    }
+
     const type = typeof value;
 
     if (type === 'string') return this.addString(name, value);


### PR DESCRIPTION
- To allow for the users of the library to set Recipient data to `null`